### PR TITLE
Added support for source vault files from the pwd and set -Path as default arg

### DIFF
--- a/AnsibleVault/AnsibleVault.psd1
+++ b/AnsibleVault/AnsibleVault.psd1
@@ -3,7 +3,7 @@
 
 @{
     RootModule = 'AnsibleVault.psm1'
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.2.0'
     GUID = '718e9512-c750-40f3-b00e-c94b20910ecb'
     Author = 'Jordan Borean'
     Copyright = 'Copyright (c) 2018 by Jordan Borean, Red Hat, licensed under MIT.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for AnsibleVault
 
+## v0.2.0 - 2018-05-25
+
+* Support getting a vault file based on the pwd when using the `-Path` parameter
+* Set the default parameter to `-Path` to better replicate the `ansible-vault` commands
+
+
 ## v0.1.0 - 2018-05-19
 
 * Initial version for the `AnsibleVault` module

--- a/Tests/Get-DecryptedAnsibleVault.Tests.ps1
+++ b/Tests/Get-DecryptedAnsibleVault.Tests.ps1
@@ -48,7 +48,21 @@ Describe "$module_name PS$ps_version tests" {
             $actual = Get-DecryptedAnsibleVault -Path "$PSScriptRoot\Resources\$Vault.vault" -Password $password
             $actual | Should -Be $expected
 
+            # repeat again and make sure omitting -Path is for the path to a vault file
+            $actual = Get-DecryptedAnsibleVault "$PSScriptRoot\Resources\$Vault.vault" -Password $password
+            $actual | Should -Be $expected
+
             $actual = $vault_contents | Get-DecryptedAnsibleVault -Password $password
+            $actual | Should -Be $expected
+        }
+        It "Can decrypt vault file in pwd not absolute path" {
+            $password = ConvertTo-SecureString -String "password" -AsPlainText -Force
+            $previous_pwd = (Get-Location).Path
+            Set-Location -Path $PSScriptRoot\Resources
+
+            $expected = (Get-Content -Path "$PSScriptRoot\Resources\small_1.1.yml" -Raw).Replace("`r`n", "`n")
+            $actual = Get-DecryptedAnsibleVault -Path "small_1.1.vault" -Password $password
+            Set-Location -Path $previous_pwd
             $actual | Should -Be $expected
         }
 

--- a/Tests/Get-EncryptedAnsibleVault.Tests.ps1
+++ b/Tests/Get-EncryptedAnsibleVault.Tests.ps1
@@ -40,7 +40,7 @@ Describe "$module_name PS$ps_version tests" {
             $actual | Should -Not -Be $actual2
 
             $actual = Get-EncryptedAnsibleVault -Path $path -Password $password
-            $actual2 = Get-EncryptedAnsibleVault -Path $path -Password $password
+            $actual2 = Get-EncryptedAnsibleVault $path -Password $password
             $actual | Should -Not -Be $plaintext
             $actual | Should -BeLike '$ANSIBLE_VAULT;1.1;AES256*'
             $actual | Should -Not -Be $actual2
@@ -60,7 +60,7 @@ Describe "$module_name PS$ps_version tests" {
 
             # now repeat the above and specify the ID
             $actual = Get-EncryptedAnsibleVault -Path $path -Password $password -Id Prod
-            $actual2 = Get-EncryptedAnsibleVault -Path $path -Password $password -Id Prod
+            $actual2 = Get-EncryptedAnsibleVault $path -Password $password -Id Prod
             $actual | Should -Not -Be $plaintext
             $actual | Should -BeLike '$ANSIBLE_VAULT;1.2;AES256;Prod*'
             $actual | Should -Not -Be $actual2
@@ -81,6 +81,17 @@ Describe "$module_name PS$ps_version tests" {
             $dec_actual = $actual | Get-DecryptedAnsibleVault -Password $password
             # last actual was the string we specified, we can assert with the actual string to make sure
             $dec_actual | Should -Be $plaintext
+        }
+        It "Can encrypt a vault file in the pwd" {
+            $password = ConvertTo-SecureString -String "password" -AsPlainText -Force
+            $previous_pwd = (Get-Location).Path
+            Set-Location -Path $PSScriptRoot\Resources
+
+            $actual = Get-EncryptedAnsibleVault -Path "small_1.1.yml" -Password $password
+            Set-Location -Path $previous_pwd
+            $actual | Should -BeLike '$ANSIBLE_VAULT;1.1;AES256*'
+            $dec_actual = $actual | Get-DecryptedAnsibleVault -Password $password
+            $dec_actual | Should -Be (Get-Content -Path "$PSScriptRoot\Resources\small_1.1.yml" -Raw)
         }
     }
 }


### PR DESCRIPTION
Allows users to specify the vault file relative to the pwd instead of defaulting to the user home dir. Also changes the default arg for each cmdlet to be for the `-Path` argument. This is actually what it was before but due to my misunderstanding the code was confusing. This fixes that up and makes the change.

Fixes https://github.com/jborean93/PowerShell-AnsibleVault/issues/1