### PR TITLE
Pwsh compatible

### DIFF
--- a/AnsibleVault/AnsibleVault.psd1
+++ b/AnsibleVault/AnsibleVault.psd1
@@ -3,7 +3,7 @@
 
 @{
     RootModule = 'AnsibleVault.psm1'
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.3.0'
     GUID = '718e9512-c750-40f3-b00e-c94b20910ecb'
     Author = 'Jordan Borean'
     Copyright = 'Copyright (c) 2018 by Jordan Borean, Red Hat, licensed under MIT.'

--- a/AnsibleVault/Private/Add-Pkcs7Padding.ps1
+++ b/AnsibleVault/Private/Add-Pkcs7Padding.ps1
@@ -5,24 +5,24 @@ Function Add-Pkcs7Padding {
     <#
     .SYNOPSIS
     Add padding to the byte array based on the PKCS7 padding spec.
-    
+
     .DESCRIPTION
     Will add PKCS7 padding to a byte array. This will always add the padding
     even if it has already been padded as there is no real way to determine
     if the padding has already been applied.
-    
+
     .PARAMETER Value
     [byte[]] The bytes to add the padding to.
-    
+
     .PARAMETER BlockSize
     [int] The size of the block in bits.
 
     .OUTPUTS
     [byte[]] The input bytes after being padded to the BlockSize.
-    
+
     .EXAMPLE
     Add-Pkcs7Padding -Value @([byte]1, [byte]2) -BlockSize 128
-    
+
     .NOTES
     Usually this is done as part of a crypto provider but because we use
     Invoke-AESCTRCycle (AES in CTR mode/stream cipher) we need to manually

--- a/AnsibleVault/Private/Convert-ByteToHex.ps1
+++ b/AnsibleVault/Private/Convert-ByteToHex.ps1
@@ -5,20 +5,20 @@ Function Convert-ByteToHex {
     <#
     .SYNOPSIS
     Converts a byte array to a string of hex characters.
-    
+
     .DESCRIPTION
     Takes in a byte array and returns the hex string representation of each
     byte.
-    
+
     .PARAMETER Value
     [byte[]] The byte array to create the hex string from.
 
     .RETURNS HexString
     [String] The hex string of the byte array.
-    
+
     .EXAMPLE
     Convert-BytesToHex -Value [byte[]]@(72, 101, 108, 108, 111)
-    
+
     .NOTES
     No special notes.
     #>

--- a/AnsibleVault/Private/Convert-HexToByte.ps1
+++ b/AnsibleVault/Private/Convert-HexToByte.ps1
@@ -5,20 +5,20 @@ Function Convert-HexToByte {
     <#
     .SYNOPSIS
     Converts a string of hex characters to a byte array.
-    
+
     .DESCRIPTION
     Takes in a string of hex characters and returns the byte array that the
     hex represents.
-    
+
     .PARAMETER Value
     [String] The hex string to convert.
 
     .OUTPUTS
     [byte[]] The byte array based on the converted hex string.
-    
+
     .EXAMPLE
     Convert-HexToBytes -Value "48656c6c6f20576f726c64"
-    
+
     .NOTES
     The hex string should have no spaces that separate each hex char.
     #>

--- a/AnsibleVault/Private/Get-HMACValue.ps1
+++ b/AnsibleVault/Private/Get-HMACValue.ps1
@@ -5,23 +5,23 @@ Function Get-HMACValue {
     <#
     .SYNOPSIS
     Generates the HMAC hex string of a byte array.
-    
+
     .DESCRIPTION
     Generates the HMAC hex string of a byte array using the SHA256 algorithm
     and the Key specified.
-    
+
     .PARAMETER Value
     [byte[]] The byte array to compute the hash from.
-    
+
     .PARAMETER Key
     [byte[]] The key to use as part of the HMAC function.
 
     .OUTPUTS
     [String] The hex string of the HMAC output.
-    
+
     .EXAMPLE
     Get-HMACValue -Value $bytes -Key $key
-    
+
     .NOTES
     This is locked in to use the SHA256 algorithm, in the future this may
     change and be configurable but right now Ansible Vault only uses this.

--- a/AnsibleVault/Private/Get-VaultHeader.ps1
+++ b/AnsibleVault/Private/Get-VaultHeader.ps1
@@ -5,11 +5,11 @@ Function Get-VaultHeader {
     <#
     .SYNOPSIS
     Parses the vault text and get's the header information.
-    
+
     .DESCRIPTION
     Takes in the full vault string and returns the header information as well
     as the byte array of the encrypted bytes.
-    
+
     .PARAMETER Value
     [String] The Ansible vault contents as a string.
 
@@ -21,10 +21,10 @@ Function Get-VaultHeader {
     [String] The ID of the vault.
 
     [byte[]] The byte array of the encrypted vault contents.
-    
+
     .EXAMPLE
     Get-VaultHeader -Value $vault_text
-    
+
     .NOTES
     Currently only the 1.1 and 1.2 versions of Ansible Vault is supported,
     as of writting this, they are the latest and only supported versions in
@@ -33,9 +33,9 @@ Function Get-VaultHeader {
     [CmdletBinding()]
     [OutputType([Object[]])]
     param(
-        [Parameter(Mandatory=$true)] [String]$Value
+        [Parameter(Mandatory = $true)] [String]$Value
     )
-    $vault_lines = $Value.Split(@("`r`n", "`r", "`n"), [System.StringSplitOptions]::RemoveEmptyEntries)
+    $vault_lines = $Value -split "[\r\n]" | Where-Object {$_}
     $header = $vault_lines[0].Trim().Split(";")
 
     $version = [Version]$header[1].Trim()

--- a/AnsibleVault/Private/Invoke-AESCTRCycle.ps1
+++ b/AnsibleVault/Private/Invoke-AESCTRCycle.ps1
@@ -5,27 +5,27 @@ Function Invoke-AESCTRCycle {
     <#
     .SYNOPSIS
     Uses AES in CTR mode to encrypt/decrypt a byte array.
-    
+
     .DESCRIPTION
     Uses the AES encryption mechanism in CTR block mode to transform input
     bytes. This function can be used to encrypt and decrypt the bytes in the
     Ansible Vault with relative ease. Because AES in CTR mode is a stream
     cipher, the input bytes does not have to be the same as the AES block size.
-    
+
     .PARAMETER Value
     [byte[]] The input bytes to transform.
-    
+
     .PARAMETER Key
     [byte[]] The key used to increment the nonce/counter used as part of the
     byte transformation process.
-    
+
     .PARAMETER Nonce
     [byte[]] The nonce/counter used to XOR the input bytes and transform it to
     the output bytes
 
     .OUTPUTS
     [byte[]] The encrypted/decrypted bytes after running through a cycle.
-    
+
     .NOTES
     The .NET class AesCryptoServiceProvider does not have a native
     CTR mode so this must be done manually. Thanks to Hans Wolff at
@@ -51,7 +51,7 @@ Function Invoke-AESCTRCycle {
         if ($xor_mask.Count -eq 0) {
             $counter_mode_block = New-Object -TypeName byte[] -ArgumentList ($counter_cipher.BlockSize / 8)
             $counter_encryptor.TransformBlock($Nonce, 0, $Nonce.Length, $counter_mode_block, 0) > $null
-    
+
             for ($j = $Nonce.Length - 1; $j -ge 0; $j--) {
                 $current_nonce_value = $Nonce[$j]
                 if ($current_nonce_value -eq 255) {
@@ -64,12 +64,12 @@ Function Invoke-AESCTRCycle {
                     break
                 }
             }
-    
+
             foreach ($counter_byte in $counter_mode_block) {
                 $xor_mask.Enqueue($counter_byte)
             }
         }
-        
+
         $current_mask = $xor_mask.Dequeue()
         $output[$i] = [byte]($Value[$i] -bxor $current_mask)
     }

--- a/AnsibleVault/Private/Invoke-Win32Api.ps1
+++ b/AnsibleVault/Private/Invoke-Win32Api.ps1
@@ -17,16 +17,16 @@ Function Invoke-Win32Api {
     sources I used were;
     # http://www.leeholmes.com/blog/2007/10/02/managing-ini-files-with-powershell/
     # https://blogs.technet.microsoft.com/heyscriptingguy/2013/06/27/use-powershell-to-interact-with-the-windows-api-part-3/
-    
+
     .PARAMETER DllName
     [String] The DLL to import the method from.
-    
+
     .PARAMETER MethodName
     [String] The name of the method.
-    
+
     .PARAMETER ReturnType
     [Type] The type of the return object returned by the method.
-    
+
     .PARAMETER ParameterTypes
     [Type[]] Array of types that define the parameter types required by the
     method. The type index should match the index of the value in the
@@ -34,7 +34,7 @@ Function Invoke-Win32Api {
 
     If the parameter is a reference or an out parameter, use [Ref] as the type
     for that parameter.
-    
+
     .PARAMETER Parameters
     [Object[]] Array of objects to supply for the parameter values required by
     the method. The value index should match the index of the value in the
@@ -42,11 +42,11 @@ Function Invoke-Win32Api {
 
     If the parameter is a reference or an out parameter, the object should be a
     [Ref] of the parameter.
-    
+
     .PARAMETER SetLastError
     [Bool] Whether to apply the SetLastError Dll attribute on the method,
     default is $false
-    
+
     .PARAMETER CharSet
     [Runtime.InteropServices.CharSet] The charset to apply to the CharSet Dll
     attribute on the method, default is [Runtime.InteropServices.CharSet]::Auto
@@ -54,7 +54,7 @@ Function Invoke-Win32Api {
     .OUTPUTS
     [Object] The return result from the method, the type of this value is based
     on the ReturnType parameter.
-    
+
     .EXAMPLE
     # Use the Win32 APIs to open a file handle
     $handle = Invoke-Win32Api -DllName kernel32.dll `
@@ -115,7 +115,7 @@ Function Invoke-Win32Api {
         throw [System.ComponentModel.Win32Exception]$last_err
     }
     Write-Output "SID: $sid_string, Domain: $($domain_name.ToString()), Name: $($name.ToString())"
-    
+
     .NOTES
     The parameters to use for a method dynamically based on the method that is
     called. There is no cut and fast way to automatically convert the interface
@@ -125,11 +125,11 @@ Function Invoke-Win32Api {
     [CmdletBinding()]
     [OutputType([Object])]
     param(
-        [Parameter(Position=0, Mandatory=$true)] [String]$DllName,
-        [Parameter(Position=1, Mandatory=$true)] [String]$MethodName,
-        [Parameter(Position=2, Mandatory=$true)] [Type]$ReturnType,
-        [Parameter(Position=3)] [Type[]]$ParameterTypes = [Type[]]@(),
-        [Parameter(Position=4)] [Object[]]$Parameters = [Object[]]@(),
+        [Parameter(Position = 0, Mandatory = $true)] [String]$DllName,
+        [Parameter(Position = 1, Mandatory = $true)] [String]$MethodName,
+        [Parameter(Position = 2, Mandatory = $true)] [Type]$ReturnType,
+        [Parameter(Position = 3)] [Type[]]$ParameterTypes = [Type[]]@(),
+        [Parameter(Position = 4)] [Object[]]$Parameters = [Object[]]@(),
         [Parameter()] [Bool]$SetLastError = $false,
         [Parameter()] [Runtime.InteropServices.CharSet]$CharSet = [Runtime.InteropServices.CharSet]::Auto
     )
@@ -139,7 +139,9 @@ Function Invoke-Win32Api {
 
     # First step is to define the dynamic assembly in the current AppDomain
     $assembly = New-Object -TypeName System.Reflection.AssemblyName -ArgumentList "Win32ApiAssembly"
-    $dynamic_assembly = [AppDomain]::CurrentDomain.DefineDynamicAssembly($assembly, [Reflection.Emit.AssemblyBuilderAccess]::Run)
+    $AssemblyBuilder = [System.Reflection.Assembly].Assembly.GetTypes() | Where-Object { $_.Name -eq 'AssemblyBuilder' }
+    $dynamic_assembly = $AssemblyBuilder::DefineDynamicAssembly($assembly, [Reflection.Emit.AssemblyBuilderAccess]::Run)
+
 
     # Second step is to create the dynamic module and type/class that contains
     # the P/Invoke definition
@@ -151,7 +153,7 @@ Function Invoke-Win32Api {
     $parameter_types = $ParameterTypes.Clone()
     for ($i = 0; $i -lt $ParameterTypes.Length; $i++) {
         if ($ParameterTypes[$i] -eq [Ref]) {
-            $parameter_types[$i]  = $Parameters[$i].Value.GetType().MakeByRefType()
+            $parameter_types[$i] = $Parameters[$i].Value.GetType().MakeByRefType()
         }
     }
 

--- a/AnsibleVault/Private/New-PBKDF2Key.ps1
+++ b/AnsibleVault/Private/New-PBKDF2Key.ps1
@@ -5,7 +5,7 @@ Function New-PBKDF2Key {
     <#
     .SYNOPSIS
     Uses the PBKDF2 functiion to derive a key used in cryptographic functions.
-    
+
     .DESCRIPTION
     This function can be used to generated a cryptographically secure key based
     on the PBKDF2 function. This function calls some native Win32 APIs as the
@@ -15,34 +15,34 @@ Function New-PBKDF2Key {
     Because we want this script to run on older versions on Windows and Ansible
     Vault uses the SHA256 algorithm we have to resort to using the native
     function BCryptDeriveKeyPBKDF2.
-    
+
     .PARAMETER Algorithm
     [String] Specifies the algorithm to use for the HMAC calculation. This must
     be one of the algorithm identifiers specified in
     https://msdn.microsoft.com/en-us/library/windows/desktop/aa375534.aspx.
-    
+
     .PARAMETER Password
     [SecureString] The password used as the part of the PBKDF2 function.
-    
+
     .PARAMETER Salt
     [byte[]] The salt used as part of the PBKDF2 function.
-    
+
     .PARAMETER Length
     [UInt32] The length of the derived key.
-    
+
     .PARAMETER Iterations
     [UInt64] The number of iterations for the PBKDF2 function.
 
     .OUTPUTS
     [byte[]] The derived key of the PBKDF2 function run.
-    
+
     .EXAMPLE
     $salt = New-Object -TypeName byte[] -ArgumentList 32
     $random_gen = New-Object -TypeName System.Security.Cryptography.RNGCryptoServiceProvider
     $random_gen.GetBytes($salt)
 
     New-PBKDF2Key -Algorithm SHA256 -Password $sec_string -Salt $salt -Length 32 -Iterations 10000
-    
+
     .NOTES
     As Windows has not automatic marshalling for a SecureString to a P/Invoke
     call, the SecureString is temporarily assigned to a IntPtr before being
@@ -98,7 +98,7 @@ Function New-PBKDF2Key {
         } finally {
             [System.Runtime.InteropServices.Marshal]::ZeroFreeGlobalAllocAnsi($pass)
         }
-        
+
         if ($res -ne 0) {
             if ($return_codes.ContainsKey($res.ToString())) {
                 $exception_msg = $return_codes.$($res.ToString())
@@ -106,7 +106,7 @@ Function New-PBKDF2Key {
                 $hex_code = ("{0:x8}" -f $res).ToUpper()
                 $exception_msg = "Unknown error (0x$hex_code)"
             }
-            
+
             throw "Failed to derive key: $exception_msg"
         }
     } finally {
@@ -122,7 +122,7 @@ Function New-PBKDF2Key {
                 $hex_code = ("{0:x8}" -f $res).ToUpper()
                 $exception_msg = "Unknown error (0x$hex_code)"
             }
-            
+
             throw "Failed to close algorithm provider: $exception_msg"
         }
     }

--- a/AnsibleVault/Private/New-VaultKey.ps1
+++ b/AnsibleVault/Private/New-VaultKey.ps1
@@ -5,14 +5,14 @@ Function New-VaultKey {
     <#
     .SYNOPSIS
     Generates the various keys required for vault encryption/decryption.
-    
+
     .DESCRIPTION
     Generates the Cipher, HMAC, and AES CTR Nonce used as part of the Vault
     operations.
-    
+
     .PARAMETER Password
     [SecureString] The password used to derive the key.
-    
+
     .PARAMETER Salt
     [byte[]] The salt used to derive the key.
 
@@ -22,13 +22,13 @@ Function New-VaultKey {
     [byte[]] The used as part of the HMAC calculation.
 
     [byte[]] The nonce/counter used in the AES CTR cipher.
-    
+
     .EXAMPLE
     $salt = New-Object -TypeName byte[] -ArgumentList 32
     $random_gen = New-Object -TypeName System.Security.Cryptography.RNGCryptoServiceProvider
     $random_gen.GetBytes($salt)
     New-VaultKeys -Password $sec_string -Salt $salt
-    
+
     .NOTES
     On decryption, the salt is stored in the cipher bytes whiile the salt must
     be randomly generated when creating a vault.

--- a/AnsibleVault/Private/Remove-Pkcs7Padding.ps1
+++ b/AnsibleVault/Private/Remove-Pkcs7Padding.ps1
@@ -5,23 +5,23 @@ Function Remove-Pkcs7Padding {
     <#
     .SYNOPSIS
     Removes PKCS7 padding on a paddded byte array.
-    
+
     .DESCRIPTION
     Will remove any PKCS7 padding on a byte array. This can be run multiple
     times and the result will always be the same.
-    
+
     .PARAMETER Value
     [byte[]] The bytes to add the remove from.
-    
+
     .PARAMETER BlockSize
     [int] The size of the block in bits.
 
     .OUTPUTS
     [byte[]] The input byte array that has been unpadded.
-    
+
     .EXAMPLE
     Remove-Pkcs7Padding -Bytes [byte[]]@(1, 2, 3, 5, 5, 5, 5 ,5) -BlockSize 64
-    
+
     .NOTES
     Usually this is done as part of a crypto provider but because we use
     Invoke-AESCTRCycle (AES in CTR mode/stream cipher) we need to manually

--- a/AnsibleVault/Private/Split-Byte.ps1
+++ b/AnsibleVault/Private/Split-Byte.ps1
@@ -5,28 +5,28 @@ Function Split-Byte {
     <#
     .SYNOPSIS
     Splits a byte array based on the character specified.
-    
+
     .DESCRIPTION
     Takes in a byte array and splits into an ArrayList based on the character
     specified by Char.
-    
+
     .PARAMETER Value
     [byte[]] The byte array to split.
-    
+
     .PARAMETER Char
     [char] The char to split the byte array with.
-    
+
     .PARAMETER MaxSplit
     [int] If specified, this is maximum number of splits that will occur.
 
     .OUTPUTS
     [System.Collections.ArrayList] The array list that contains each split.
-    
+
     .EXAMPLE
     Split-Bytes -Value -Char ([char]"`n")
 
     Split-Bytes -Value $byte_array -Char ([char]"a") -MaxSplit 2
-    
+
     .NOTES
     The MaxSplit parameter is the number of times a split will occur and not
     number of entries in the returned ArrayList. For example -MaxSplit of 2 but

--- a/AnsibleVault/Public/Get-DecryptedAnsibleVault.ps1
+++ b/AnsibleVault/Public/Get-DecryptedAnsibleVault.ps1
@@ -5,19 +5,19 @@ Function Get-DecryptedAnsibleVault {
     <#
     .SYNOPSIS
     Decrypt an Ansible Vault string and return the plaintext as a string.
-    
+
     .DESCRIPTION
     This cmdlet will take in a Ansible Vault string and return the decrypted
     value.
-    
+
     .PARAMETER Path
     [String] The path to a file whose contents will be decrypted. This is
     mutually exclusive to the Value parameter.
-    
+
     .PARAMETER Value
     [String] The string value to decrypt. This is mutually exclusive to the
     Path parameter.
-    
+
     .PARAMETER Password
     [SecureString] The password used to decrypt the value with
 
@@ -32,7 +32,7 @@ Function Get-DecryptedAnsibleVault {
 
     .OUTPUTS
     [String] The decrypted vault string.
-    
+
     .EXAMPLE
     # Create the secure string that stores the vault password
     $password = Read-Host -AsSecureString
@@ -48,7 +48,7 @@ Function Get-DecryptedAnsibleVault {
 
     # decrypt vault that had the original plaintext encoded as UTF-16
     Get-DecryptedAnsibleVault -Value $vault_text -Password $password -Encoding ([System.Text.Encoding]::Unicode)
-    
+
     .NOTES
     This only supports the vault versions 1.1 and 1.2. These version are mostly
     identical but 1.2 is used when the Id parameter is specified. This should

--- a/AnsibleVault/Public/Get-EncryptedAnsibleVault.ps1
+++ b/AnsibleVault/Public/Get-EncryptedAnsibleVault.ps1
@@ -5,22 +5,22 @@ Function Get-EncryptedAnsibleVault {
     <#
     .SYNOPSIS
     Create an encrypted string the is compatible with Ansible Vault.
-    
+
     .DESCRIPTION
     This cmdlet will take in a string or path to a file to encrypt and then
     return the encrypted Ansible Vault text.
-    
+
     .PARAMETER Path
     [String] The path to a file whose contents will be encrypted. This is
     mutually exclusive to the Value parameter.
-    
+
     .PARAMETER Value
     [String] The string value to encrypt. This is mutually exclusive to the
     Path parameter.
-    
+
     .PARAMETER Password
     [SecureString] The password used to encrypt the value with
-    
+
     .PARAMETER Id
     [String] The ID to specify for the created vault. If not specified then no
     ID will be applied. This is only supported in Ansible since the 2.4
@@ -31,7 +31,7 @@ Function Get-EncryptedAnsibleVault {
 
     .OUTPUTS
     [String] The encrypted vault string.
-    
+
     .EXAMPLE
     # Create the secure string that stores the vault password
     $password = Read-Host -AsSecureString
@@ -47,7 +47,7 @@ Function Get-EncryptedAnsibleVault {
 
     # create a vault string with a specific ID
     Get-EncryptedAnsibleVault -Value "variable: abc`nvariable2: def" -Password $password -Id Prod
-    
+
     .NOTES
     This only supports the vault versions 1.1 and 1.2. These version are mostly
     identical but 1.2 is used when the Id parameter is specified. This should

--- a/Tests/Convert-HexToByte.Tests.ps1
+++ b/Tests/Convert-HexToByte.Tests.ps1
@@ -15,7 +15,7 @@ Describe "$module_name PS$ps_version tests" {
         It 'should get valid bytes' {
             $expected = [byte[]]@(72, 101, 108, 108, 111)
             $actual = Convert-HexToByte -Value "48656c6c6f"
-            
+
             $actual.Length | Should -Be $expected.Count
             for ($i = 0; $i -lt $actual.Count; $i++) {
                 $actual[$i] | Should -Be $expected[$i]

--- a/Tests/Get-DecryptedAnsibleVault.Tests.ps1
+++ b/Tests/Get-DecryptedAnsibleVault.Tests.ps1
@@ -37,7 +37,7 @@ Describe "$module_name PS$ps_version tests" {
             if ($VaultSecret -is [byte[]]) {
                 $VaultSecret = [System.Text.Encoding]::UTF8.GetString($VaultSecret)
             }
-            
+
             $vault_contents = Get-Content -Path "$PSScriptRoot\Resources\$Vault.vault" -Raw
             $expected = (Get-Content -Path "$PSScriptRoot\Resources\$Vault.yml" -Raw).Replace("`r`n", "`n")
             $password = ConvertTo-SecureString -String $VaultSecret -AsPlainText -Force

--- a/Tests/Get-EncryptedAnsibleVault.Tests.ps1
+++ b/Tests/Get-EncryptedAnsibleVault.Tests.ps1
@@ -21,7 +21,7 @@ Describe "$module_name PS$ps_version tests" {
             @{ Vault = "dev_1.2"; VaultSecret = 'WsT2Wf!MnHctYXIQbI%xr$L8aid@fLTS6tA*' }
         ) {
             param ($Vault, $VaultSecret)
-            
+
             $path = "$PSScriptRoot\Resources\$Vault.yml"
             $plaintext = (Get-Content -Path $path -Raw).Replace("`r`n", "`n")
             $password = ConvertTo-SecureString -String $VaultSecret -AsPlainText -Force

--- a/Tests/Invoke-AESCTRCycle.Tests.ps1
+++ b/Tests/Invoke-AESCTRCycle.Tests.ps1
@@ -171,7 +171,7 @@ Describe "$module_name PS$ps_version tests" {
             $actual = Invoke-AESCTRCycle -Value (Convert-HexToByte -Value $InputHex) `
                 -Nonce (Convert-HexToByte -Value $Counter) `
                 -Key (Convert-HexToByte -Value $Key)
-            
+
             $actual | Should -Be $expected
         }
     }

--- a/Tests/Invoke-Win32Api.Tests.ps1
+++ b/Tests/Invoke-Win32Api.Tests.ps1
@@ -59,12 +59,12 @@ Describe "$module_name PS$ps_version tests" {
             $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $sid_string
             $sid_bytes = New-Object -TypeName byte[] -ArgumentList $sid.BinaryLength
             $sid.GetBinaryForm($sid_bytes, 0)
-        
+
             $name = New-Object -TypeName System.Text.StringBuilder
             $name_length = 0
             $domain_name = New-Object -TypeName System.Text.StringBuilder
             $domain_name_length = 0
-        
+
             $invoke_args = @{
                 DllName = "Advapi32.dll"
                 MethodName = "LookupAccountSidW"
@@ -82,7 +82,7 @@ Describe "$module_name PS$ps_version tests" {
                 SetLastError = $true
                 CharSet = "Unicode"
             }
-        
+
             $res = Invoke-Win32Api @invoke_args
             $name.EnsureCapacity($name_length)
             $domain_name.EnsureCapacity($domain_name_length)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,3 +13,4 @@ build: false
 
 test_script:
 - ps: . .\build.ps1
+- pwsh: . .\build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -56,6 +56,7 @@ Get-PackageProvider -Name NuGet -ForceBootstrap | Out-Null
 
 Resolve-Module Psake, PSDeploy, Pester, BuildHelpers, PsScriptAnalyzer
 
+Get-ChildItem env:BH* | ForEach-Object {[Environment]::SetEnvironmentVariable($_.name, "")}
 Set-BuildEnvironment
 
 Invoke-psake .\psake.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -37,7 +37,14 @@ function Resolve-Module
             else
             {
                 Write-Verbose -Message "$($ModuleName) Missing, installing Module"
-                Install-Module -Name $ModuleName -Force
+                if ($ModuleName -eq "PSScriptAnalyzer"){
+                    # PSScriptAnalyzer v1.18.3 (2019.09.17) is only compatible with pwsh v6.2.0+,
+                    # but pwsh v6.1.0 is installed on Appveyor.
+                    if (($PSVersionTable.PSVersion.Major -ge 6 ) -and ($PSVersionTable.PSVersion -lt "6.2.0")) {
+                        $Version = "1.18.2"
+                    }
+                }
+                Install-Module -Name $ModuleName -Force -RequiredVersion $Version
                 Import-Module -Name $ModuleName -Force -RequiredVersion $Version
             }
         }


### PR DESCRIPTION
Hello,

This PR makes the module compatible to pwsh v6 and v7.
(with some minor code format changes done by the editor automatically.)

Tested powershell versions : 
- powershell v5.1
- pwsh v6.2.2
- pwsh v7.0.0-preview.3

Only one test failed : 

```
[-] Can decrypt vault unicode_1.1 with password @(195, 162, 194, 157, 197, 146, 195, 162, 197, 190) 255ms
        ArgumentException: HMAC verification failed, was the wrong password entered?
```